### PR TITLE
compatible to C++11

### DIFF
--- a/kyototycoon/ktulog.h
+++ b/kyototycoon/ktulog.h
@@ -48,7 +48,7 @@ class UpdateLogger {
   /* The accuracy of logical time stamp. */
   static const uint64_t TSLACC = 1000 * 1000;
   /* The waiting seconds of auto flush. */
-  static const double FLUSHWAIT = 0.1;
+  static constexpr double FLUSHWAIT = 0.1f;
  public:
   /**
    * Reader of update logs.


### PR DESCRIPTION
In C++11, non-static data members, static constexpr data members, and static const data members of integral or enumeration type may be initialized in the class declaration. Since float and double are not of integral or enumeration type, such members must either be constexpr, or non-static in order for the initializer in the class definition to be permitted. Prior to C++11, only static const data members of integral or enumeration type could have initializers in the class definition. [From https://stackoverflow.com/a/9208326/294577]